### PR TITLE
Mapping parameter is not assigned during constructor call for EvdevHandler

### DIFF
--- a/src/com/limelight/input/EvdevHandler.java
+++ b/src/com/limelight/input/EvdevHandler.java
@@ -36,6 +36,7 @@ public class EvdevHandler implements Runnable {
 	
 	public EvdevHandler(NvConnection conn, String device, GamepadMapping mapping) throws FileNotFoundException, IOException {
 		this.conn = conn;
+		this.mapping = mapping;
 		File file = new File(device);
 		if (!file.exists())
 			throw new FileNotFoundException("File " + device + " not found");


### PR DESCRIPTION
Hi,
first of all, thanks for this awesome port. I just tried to run it on my pi, but noticed input from a controller is not registered.

After some digging, I found that the mapping parameter is not assigned to the respective instance variable in the EvdevHandler class. This results in a NullPointerException during parseEvent if input from the controller is present.
The attached request should fix the problem.

If you need anything else in order to accept this pull request, please let me know.

Best regards,
  Christian
