### PR TITLE
Mouse emulation support for evdev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ include_directories("${PROJECT_BINARY_DIR}")
 add_subdirectory(libgamestream)
 
 add_executable(moonlight ${SRC_LIST})
+target_link_libraries(moonlight m)
 target_link_libraries(moonlight gamestream)
 
 if (CEC_FOUND)


### PR DESCRIPTION
**Description**
This PR adds support for mouse emulation mode on game controllers. It is only implemented in *evdev* input backend.
This feature already exists on moonlight-android and moonlight-qt and this code is inspired by the implentation on moonlight-qt.

This PR doesn't implement mouse emulation for SDL and X11 input backends, as I have no devices for testing these kinds of implementations.

Because moonlight-qt uses math libraries for pow() function, I also had to link moonlight against **libm**.

**Purpose**
Game controller can now be emulated as a mouse using evdev input backend.
Mouse emulation is toggled by long pressing Start button. The feature works similarly to moonlight-qt's implementation.

It has been tested on a Raspberry PI and an Amlogic box.