### PR TITLE
Initializing new members of mapping struct

### DIFF
--- a/src/input/mapping.c
+++ b/src/input/mapping.c
@@ -39,7 +39,7 @@ struct mapping* mapping_parse(char* mapping) {
 
   strncpy(map->guid, guid, sizeof(map->guid));
   strncpy(map->name, name, sizeof(map->name));
-  memset(&map->abs_leftx, -1, sizeof(short) * 31);
+  memset(&map->abs_leftx, -1, sizeof(short) * 35);
 
   char* option;
   while ((option = strtok_r(NULL, ",", &strpoint)) != NULL) {


### PR DESCRIPTION
**Description**
This initializes the new members recently added to the mapping struct to default values.

**Purpose**
After recently updating I was having a number of bizarre input issues. I tracked it down to this commit: e8fbb2ec9ca45a5cd870afe1db1b5b994dad74c9 and realized the new members added to the mapping struct were not being initialized. Fixing that seems to have cured the problems I having.

A more robust solution would probably be good here, but this gets it working for now.