### PR TITLE
Flush pair code for external scripts

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -371,6 +371,7 @@ int main(int argc, char* argv[]) {
     char pin[5];
     sprintf(pin, "%d%d%d%d", (int)random() % 10, (int)random() % 10, (int)random() % 10, (int)random() % 10);
     printf("Please enter the following PIN on the target PC: %s\n", pin);
+    fflush(stdout);
     if (gs_pair(&server, &pin[0]) != GS_OK) {
       fprintf(stderr, "Failed to pair to server: %s\n", gs_error);
     } else {


### PR DESCRIPTION
**Description**
Flush pair code on 'moonlight pair'.

**Purpose**
Allows pair code (PIN) for external scripts. The stdout is usually buffered, meaning that line can't be read by external scripts until the executable is done executing. This allows scraping the code from a script.