### PR TITLE
[X11] fix cursor jumping when grabbed

### DIFF
--- a/src/input/x11.c
+++ b/src/input/x11.c
@@ -36,7 +36,7 @@
 
 static Display *display;
 static Window window;
-static Event event;
+static XEvent event;
 
 static Atom wm_deletemessage;
 
@@ -74,8 +74,6 @@ static int x11_handle_motion_notify() {
     last_y = grabbed ? 360 : event.xmotion.y;
   }
 }
-
-static int x11_prepare
 
 static int x11_handler(int fd) {
   int button = 0;

--- a/src/input/x11.c
+++ b/src/input/x11.c
@@ -36,6 +36,7 @@
 
 static Display *display;
 static Window window;
+static Event event;
 
 static Atom wm_deletemessage;
 
@@ -46,101 +47,120 @@ static const char data[1] = {0};
 static Cursor cursor;
 static bool grabbed = True;
 
+static int motion_x, motion_y;
+
+static int x11_handle_motion_notify() {
+  motion_x = 0;
+  motion_y = 0;
+  int i;
+  for (
+    i = 0;
+    i <= 20 &&
+    XPending(display) &&
+    XCheckMaskEvent(display, PointerMotionMask, &event);
+    ++i
+  ) {}
+  if (i > 0) {
+    motion_x = event.xmotion.x - last_x;
+    motion_y = event.xmotion.y - last_y;
+    if (abs(motion_x) > 0 || abs(motion_y) > 0) {
+    if (last_x >= 0 && last_y >= 0)
+       LiSendMouseMoveEvent(motion_x, motion_y);
+
+    if (grabbed)
+      XWarpPointer(display, None, window, 0, 0, 0, 0, 640, 360);
+    }
+    last_x = grabbed ? 640 : event.xmotion.x;
+    last_y = grabbed ? 360 : event.xmotion.y;
+  }
+}
+
+static int x11_prepare
+
 static int x11_handler(int fd) {
-  XEvent event;
   int button = 0;
-  int motion_x, motion_y;
 
   while (XPending(display)) {
-    XNextEvent(display, &event);
-    switch (event.type) {
-    case KeyPress:
-    case KeyRelease:
-      if (event.xkey.keycode >= 8 && event.xkey.keycode < (sizeof(keyCodes)/sizeof(keyCodes[0]) + 8)) {
-        if ((keyboard_modifiers & ACTION_MODIFIERS) == ACTION_MODIFIERS && event.type == KeyRelease) {
-          if (event.xkey.keycode == QUIT_KEY)
-            return LOOP_RETURN;
-          else {
-            grabbed = !grabbed;
-            XDefineCursor(display, window, grabbed ? cursor : 0);
+    XPeekEvent(display, &event);
+    x11_handle_motion_notify();
+    if (XCheckMaskEvent(display, ~PointerMotionMask, &event)) {
+      switch (event.type) {
+      case KeyPress:
+      case KeyRelease:
+        if (event.xkey.keycode >= 8 && event.xkey.keycode < (sizeof(keyCodes)/sizeof(keyCodes[0]) + 8)) {
+          if ((keyboard_modifiers & ACTION_MODIFIERS) == ACTION_MODIFIERS && event.type == KeyRelease) {
+            if (event.xkey.keycode == QUIT_KEY)
+              return LOOP_RETURN;
+            else {
+              grabbed = !grabbed;
+              XDefineCursor(display, window, grabbed ? cursor : 0);
+            }
           }
+
+          int modifier = 0;
+          switch (event.xkey.keycode) {
+          case 0x32:
+          case 0x3e:
+            modifier = MODIFIER_SHIFT;
+            break;
+          case 0x40:
+          case 0x6c:
+            modifier = MODIFIER_ALT;
+            break;
+          case 0x25:
+          case 0x69:
+            modifier = MODIFIER_CTRL;
+            break;
+          }
+
+          if (modifier != 0) {
+            if (event.type == KeyPress)
+              keyboard_modifiers |= modifier;
+            else
+              keyboard_modifiers &= ~modifier;
+          }
+
+          short code = 0x80 << 8 | keyCodes[event.xkey.keycode - 8];
+          LiSendKeyboardEvent(code, event.type == KeyPress ? KEY_ACTION_DOWN : KEY_ACTION_UP, keyboard_modifiers);
+        }
+        break;
+      case ButtonPress:
+      case ButtonRelease:
+        switch (event.xbutton.button) {
+        case Button1:
+          button = BUTTON_LEFT;
+          break;
+        case Button2:
+          button = BUTTON_MIDDLE;
+          break;
+        case Button3:
+          button = BUTTON_RIGHT;
+          break;
+        case Button4:
+          LiSendScrollEvent(1);
+          break;
+        case Button5:
+          LiSendScrollEvent(-1);
+          break;
+        case 8:
+          button = BUTTON_X1;
+          break;
+        case 9:
+          button = BUTTON_X2;
+          break;
         }
 
-        int modifier = 0;
-        switch (event.xkey.keycode) {
-        case 0x32:
-        case 0x3e:
-          modifier = MODIFIER_SHIFT;
-          break;
-        case 0x40:
-        case 0x6c:
-          modifier = MODIFIER_ALT;
-          break;
-        case 0x25:
-        case 0x69:
-          modifier = MODIFIER_CTRL;
-          break;
-        }
+        if (button != 0)
+          LiSendMouseButtonEvent(event.type==ButtonPress ? BUTTON_ACTION_PRESS : BUTTON_ACTION_RELEASE, button);
+        break;
+      case MotionNotify: //will never happen
+        break;
+      case ClientMessage:
+        if (event.xclient.data.l[0] == wm_deletemessage)
+          return LOOP_RETURN;
 
-        if (modifier != 0) {
-          if (event.type == KeyPress)
-            keyboard_modifiers |= modifier;
-          else
-            keyboard_modifiers &= ~modifier;
-        }
-
-        short code = 0x80 << 8 | keyCodes[event.xkey.keycode - 8];
-        LiSendKeyboardEvent(code, event.type == KeyPress ? KEY_ACTION_DOWN : KEY_ACTION_UP, keyboard_modifiers);
-      }
-      break;
-    case ButtonPress:
-    case ButtonRelease:
-      switch (event.xbutton.button) {
-      case Button1:
-        button = BUTTON_LEFT;
-        break;
-      case Button2:
-        button = BUTTON_MIDDLE;
-        break;
-      case Button3:
-        button = BUTTON_RIGHT;
-        break;
-      case Button4:
-        LiSendScrollEvent(1);
-        break;
-      case Button5:
-        LiSendScrollEvent(-1);
-        break;
-      case 8:
-        button = BUTTON_X1;
-        break;
-      case 9:
-        button = BUTTON_X2;
         break;
       }
-
-      if (button != 0)
-        LiSendMouseButtonEvent(event.type==ButtonPress ? BUTTON_ACTION_PRESS : BUTTON_ACTION_RELEASE, button);
-      break;
-    case MotionNotify:
-      motion_x = event.xmotion.x - last_x;
-      motion_y = event.xmotion.y - last_y;
-      if (abs(motion_x) > 0 || abs(motion_y) > 0) {
-        if (last_x >= 0 && last_y >= 0)
-          LiSendMouseMoveEvent(motion_x, motion_y);
-
-        if (grabbed)
-          XWarpPointer(display, None, window, 0, 0, 0, 0, 640, 360);
-      }
-
-      last_x = grabbed ? 640 : event.xmotion.x;
-      last_y = grabbed ? 360 : event.xmotion.y;
-      break;
-    case ClientMessage:
-      if (event.xclient.data.l[0] == wm_deletemessage)
-        return LOOP_RETURN;
-
-      break;
     }
   }
 


### PR DESCRIPTION
**Description**
i found that cursor jumps randomly when you move your cursor only when you grabbed

it occurs because you set `last_x` and `last_y` while another `MotionNotify` event is in the queue, possibly an event before `XWarpPointer` applied

this patch make sure there is no `MotionNotify` event in the queue before setting `last_x` and `last_y`, warping cursor and sending mouse move