### PR TITLE
SDL : Fix program not exiting upon disconnection, Handle intempestive controller disconnections

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -23,6 +23,10 @@
 #include <stdarg.h>
 #include <signal.h>
 
+#ifdef HAVE_SDL
+#include <SDL.h>
+#endif
+
 pthread_t main_thread_id = 0;
 bool connection_debug;
 ConnListenerRumble rumble_handler = NULL;
@@ -30,6 +34,7 @@ ConnListenerRumble rumble_handler = NULL;
 static void connection_terminated(int errorCode) {
   switch (errorCode) {
   case ML_ERROR_GRACEFUL_TERMINATION:
+    printf("Connection has been terminated gracefully.\n");
     break;
   case ML_ERROR_NO_VIDEO_TRAFFIC:
     printf("No video received from host. Check the host PC's firewall and port forwarding rules.\n");
@@ -47,6 +52,12 @@ static void connection_terminated(int errorCode) {
     printf("Connection terminated with error: %d\n", errorCode);
     break;
   }
+
+  #ifdef HAVE_SDL
+      SDL_Event event;
+      event.type = SDL_QUIT;
+      SDL_PushEvent(&event);
+  #endif
 
   if (main_thread_id != 0)
     pthread_kill(main_thread_id, SIGTERM);


### PR DESCRIPTION
This pull request fixes two problems I ran into while compiling and testing on Odroid XU4 / Ubuntu 20.04 :

1/ Program not exiting upon disconnection

I noticed that the program would wait indefinetely at the end of the stream when using SDL. As far as I understand it, the main loop used for SDL is different from the other platforms (i.e. x11). In the SDL loop, the loop ends only if the user presses a key combination to express a desire to quit. However since the stream can end on itself either gracefully when quitting the streamed app or in a dirty way in case of various situations happening server-side, in those cases the SDL loop continues indefinetely. I added a call to SDL_Event in connection.c so that if the connection ends, the SDL loop is notified and can exit gracefully.

Tested and working for me

2/ Intempestive controller disconnections

I use a wireless xbox 360 controller, and it disconnects and reconnects very often by itself, either due to poor signal or batteries moving around or maybe it's just not a quality one. Does not matter why it disconnects, moonlight should be able to handle this without problem. But with the current code, if the controller is disconnected and reconnected, it stops working. This is a problem especially when the only way to interact with the client was via the controller. To solve this, I just handled two additonal SDL events that fit very well with that situation, namely SDL_CONTROLLERDEVICEADDED and SDL_CONTROLLERDEVICEREMOVED. If those events are caught by the SDL loop, I reinit all the gamepads available so that the problem described does not occur anymore.

Tested and working for me

PLEASE NOTE : I am not a specialist of SDL or moonlight or C at all, so those changes might not be done the right/optimal way. However if you think they are worth of being included in the main codebase, I'll be happy to have contributed my 2 cents.

Thank you


