### PR TITLE
Add rotation to sample config, warn about invalid values

### DIFF
--- a/moonlight.conf
+++ b/moonlight.conf
@@ -7,6 +7,10 @@
 #height = 720
 #fps = 60
 
+## Output rotation (independent of xrandr or framebuffer settings!)
+## Allowed values: 0, 90, 180, 270
+#rotation = 0
+
 ## Bitrate depends by default on resolution and fps
 ## Set to -1 to enable default
 ## 20Mbps (20000) for 1080p (60 fps)

--- a/src/main.c
+++ b/src/main.c
@@ -119,6 +119,8 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
     drFlags |= DISPLAY_FULLSCREEN;
 
   switch (config->rotate) {
+  case 0:
+    break;
   case 90:
     drFlags |= DISPLAY_ROTATE_90;
     break;
@@ -128,6 +130,8 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
   case 270:
     drFlags |= DISPLAY_ROTATE_270;
     break;
+  default:
+    printf("Ignoring invalid rotation value: %d\n", config->rotate);
   }
 
   if (config->debug_level > 0) {
@@ -192,7 +196,7 @@ static void help() {
   printf("\t-width <width>\t\tHorizontal resolution (default 1280)\n");
   printf("\t-height <height>\tVertical resolution (default 720)\n");
   #if defined(HAVE_PI) | defined(HAVE_MMAL)
-  printf("\t-rotate <height>\tRotate display: 0/90/180/270 (default 0)\n");
+  printf("\t-rotate <angle>\tRotate display: 0/90/180/270 (default 0)\n");
   #endif
   printf("\t-fps <fps>\t\tSpecify the fps to use (default 60)\n");
   printf("\t-bitrate <bitrate>\tSpecify the bitrate in Kbps\n");


### PR DESCRIPTION
**Description**
Add `rotation` to the sample configuration file; warn about invalid rotation values (and ignore them).

**Purpose**
`rotation` in configuration file was already supported, just not documented anywhere - this fills the gap (and adds a warning on the stdout, should someone try using an invalid value).