### PR TITLE
Update Amlogic decoder

### DIFF
--- a/cmake/FindAmlogic.cmake
+++ b/cmake/FindAmlogic.cmake
@@ -4,18 +4,6 @@ find_path(AMLOGIC_INCLUDE_DIR
   PATHS /usr/local/include/amcodec /usr/osmc/include/amcodec /usr/include/amcodec /usr/include/)
 mark_as_advanced(AMLOGIC_INCLUDE_DIR)
 
-find_library(AMAVUTILS_LIBRARY
-  NAMES libamavutils.so
-  DOC "Path to Amlogic Audio Video Utils Library"
-  PATHS /usr/lib/aml_libs /usr/osmc/lib /usr/local/lib /usr/lib)
-mark_as_advanced(AMAVUTILS_LIBRARY)
-
-find_library(AMADEC_LIBRARY
-  NAMES libamadec.so
-  DOC "Path to Amlogic Audio Decoder Library"
-  PATHS /usr/lib/aml_libs /usr/osmc/lib /usr/local/lib /usr/lib)
-mark_as_advanced(AMADEC_LIBRARY)
-
 find_library(AMCODEC_LIBRARY
   NAMES libamcodec.so
   DOC "Path to Amlogic Video Codec Library"
@@ -23,7 +11,7 @@ find_library(AMCODEC_LIBRARY
 mark_as_advanced(AMCODEC_LIBRARY)
 
 include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Amlogic DEFAULT_MSG AMLOGIC_INCLUDE_DIR AMCODEC_LIBRARY AMADEC_LIBRARY AMAVUTILS_LIBRARY)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Amlogic DEFAULT_MSG AMLOGIC_INCLUDE_DIR AMCODEC_LIBRARY)
 
-set(AMLOGIC_LIBRARIES ${AMCODEC_LIBRARY} ${AMADEC_LIBRARY} ${AMAVUTILS_LIBRARY})
+set(AMLOGIC_LIBRARIES ${AMCODEC_LIBRARY})
 set(AMLOGIC_INCLUDE_DIRS ${AMLOGIC_INCLUDE_DIR})

--- a/src/platform.c
+++ b/src/platform.c
@@ -106,6 +106,7 @@ void platform_start(enum platform system) {
   case AML:
     write_bool("/sys/class/graphics/fb0/blank", true);
     write_bool("/sys/class/graphics/fb1/blank", true);
+    write_bool("/sys/class/video/disable_video", false);
     break;
   #endif
   #if defined(HAVE_PI) | defined(HAVE_MMAL)

--- a/src/platform.c
+++ b/src/platform.c
@@ -61,7 +61,7 @@ enum platform platform_check(char* name) {
   #endif
   #ifdef HAVE_AML
   if (std || strcmp(name, "aml") == 0) {
-    void *handle = dlopen("libmoonlight-aml.so", RTLD_NOW | RTLD_GLOBAL);
+    void *handle = dlopen("libmoonlight-aml.so", RTLD_LAZY | RTLD_GLOBAL);
     if (handle != NULL && access("/dev/amvideo", F_OK) != -1)
       return AML;
   }


### PR DESCRIPTION
**Description**
These commits allow the Amlogic decoder to work on boxes running CoreELEC. It has only been tested on the linux kernel 4.9.269.
 
[lazy load libamcodec]
It is required as libamcodec.so provided by CoreELEC has unresolved symbols. Since we are only using the libamcodec to provide VPU support and other libraries are not used, this fixes the build on CoreELEC.

[update amlogic decoder]
New parameters added as they are required for the latest version of proprietary libamcodec. This commit might have to be modified since not everyone has the same header files...

1. It is creating a frame_buffer as a temporary buffer so that the whole frame can be sent to the decoder at once. 

All the other solutions may work but at some point the frames get rejected with EBUSY, causing latency, stuttering and variations in speed. I don't know if we can somehow get the buffer list to have more data at once, but increasing the packet size has not fixed this.

[set disable_video to false on startup]
2. Set disable_video to false on startup. Kodi in CoreELEC sets this value to true when video is not playing so the screen will be black without this. It can be fixed by running prescripts but I feel like this would be okay to do in moonlight too.

3. Modifies aml_submit_decode_unit so it first copies all the buffer data into frame_buffer and is then provided to libamcodec.


I recommend to get this tested on more devices before being pushed to upstream. People on CoreELEC seem to have problems with this version, although in my testing I have identified that ALSA audio handling seems to be breaking the video thread. As audio gets delayed, underruns occur. This further causes the timings to break and either moonlight blocks the frames or the video thread can't keep up.

Furthermore, it is important to test this with multiple boards and configurations of VFM maps, as it seems that `/sys/class/vfm/map` breaks things.

