### PR TITLE
correct the video output rotation option

### DIFF
--- a/moonlight.conf
+++ b/moonlight.conf
@@ -9,7 +9,7 @@
 
 ## Output rotation (independent of xrandr or framebuffer settings!)
 ## Allowed values: 0, 90, 180, 270
-#rotation = 0
+#rotate = 0
 
 ## Bitrate depends by default on resolution and fps
 ## Set to -1 to enable default


### PR DESCRIPTION
**Description**
The correct parameter to rotate the video output seems to be `rotate` and not `rotation`.

**Purpose**
Improvement

Should fix https://github.com/moonlight-stream/moonlight-embedded/issues/862