### PR TITLE
Fixes and features made for the FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,6 @@ target_link_libraries(moonlight gamestream)
 
 if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
   set(ALSA_FOUND FALSE)
-  set(PULSE_FOUND FALSE)
-  set(CEC_FOUND FALSE)
   target_sources(moonlight PRIVATE ./src/audio/oss.c)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,13 @@ add_executable(moonlight ${SRC_LIST})
 target_link_libraries(moonlight m)
 target_link_libraries(moonlight gamestream)
 
+if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+  set(ALSA_FOUND FALSE)
+  set(PULSE_FOUND FALSE)
+  set(CEC_FOUND FALSE)
+  target_sources(moonlight PRIVATE ./src/audio/oss.c)
+endif()
+
 if (CEC_FOUND)
   list(APPEND MOONLIGHT_DEFINITIONS HAVE_LIBCEC)
   list(APPEND MOONLIGHT_OPTIONS CEC)

--- a/libgamestream/http.c
+++ b/libgamestream/http.c
@@ -73,6 +73,9 @@ int http_init(const char* keyDirectory, int logLevel) {
 int http_request(char* url, PHTTP_DATA data) {
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, data);
   curl_easy_setopt(curl, CURLOPT_URL, url);
+#ifdef __FreeBSD__
+  curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1);
+#endif
 
   if (debug)
     printf("Request %s\n", url);

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -31,3 +31,6 @@ extern AUDIO_RENDERER_CALLBACKS audio_callbacks_sdl;
 extern AUDIO_RENDERER_CALLBACKS audio_callbacks_pulse;
 bool audio_pulse_init(char* audio_device);
 #endif
+#ifdef __FreeBSD__
+extern AUDIO_RENDERER_CALLBACKS audio_callbacks_oss;
+#endif

--- a/src/audio/oss.c
+++ b/src/audio/oss.c
@@ -1,0 +1,105 @@
+/*
+ * This file is part of Moonlight Embedded.
+ *
+ * Copyright (C) 2015-2017 Iwan Timmer
+ *
+ * Moonlight is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moonlight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef __FreeBSD__
+#include <sys/soundcard.h>
+#include "audio.h"
+
+#include <opus_multistream.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static OpusMSDecoder* decoder;
+static short* pcmBuffer;
+static int samplesPerFrame;
+static int channelCount;
+static int fd;
+
+static int oss_renderer_init(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig, void* context, int arFlags) {
+  int rc;
+  decoder = opus_multistream_decoder_create(opusConfig->sampleRate, opusConfig->channelCount, opusConfig->streams, opusConfig->coupledStreams, opusConfig->mapping, &rc);
+
+  channelCount = opusConfig->channelCount;
+  samplesPerFrame = opusConfig->samplesPerFrame;
+  pcmBuffer = malloc(sizeof(short) * channelCount * samplesPerFrame);
+  if (pcmBuffer == NULL)
+    return -1;
+
+  const char* oss_name = "/dev/dsp";
+  fd = open(oss_name, O_WRONLY);
+  // buffer size for fragment ,selector 12 is 4096;11 is 2048;10 is 1024; 13is 8192
+  if (fd == -1) {
+    close(fd);
+    printf("Open audio device /dev/dsp faild!!!");
+    return -1;
+  }
+  int frag = 12;
+  if (ioctl(fd, SNDCTL_DSP_SETFRAGMENT, &frag) == -1)
+    printf("Set framgment for /dev/dsp faild.");
+
+  int format = AFMT_S16_LE;
+  int channels = opusConfig->channelCount;
+  int rate = opusConfig->sampleRate;
+  if (ioctl(fd, SNDCTL_DSP_SETFMT, &format) == -1)
+    printf("Set framgment for /dev/dsp faild.");
+  if (ioctl(fd, SNDCTL_DSP_CHANNELS, &channels) == -1)
+    printf("Set channels for /dev/dsp faild.");
+  if (ioctl(fd, SNDCTL_DSP_SPEED, &rate) == -1)
+    printf("Set sameple rate for /dev/dsp faild.");
+
+  return 0;
+}
+
+static void oss_renderer_cleanup() {
+  if (decoder != NULL) {
+    opus_multistream_decoder_destroy(decoder);
+    decoder = NULL;
+  }
+
+  if (pcmBuffer != NULL) {
+    free(pcmBuffer);
+    pcmBuffer = NULL;
+  }
+
+  if (fd != 0) {
+    close(fd);
+    fd = 0;
+  }
+}
+
+static void oss_renderer_decode_and_play_sample(char* data, int length) {
+  int decodeLen = opus_multistream_decode(decoder, data, length, pcmBuffer, samplesPerFrame, 0);
+  if (decodeLen > 0) {
+    write(fd, pcmBuffer, decodeLen * channelCount * sizeof(short));
+  } else {
+    printf("Opus error from decode: %d\n", decodeLen);
+  }
+}
+
+AUDIO_RENDERER_CALLBACKS audio_callbacks_oss = {
+  .init = oss_renderer_init,
+  .cleanup = oss_renderer_cleanup,
+  .decodeAndPlaySample = oss_renderer_decode_and_play_sample,
+  .capabilities = CAPABILITY_DIRECT_SUBMIT | CAPABILITY_SUPPORTS_ARBITRARY_AUDIO_DURATION,
+};
+#endif

--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -38,7 +38,11 @@
 #include <limits.h>
 #include <unistd.h>
 #include <pthread.h>
+#ifdef __linux__
 #include <endian.h>
+#else
+#include <sys/endian.h>
+#endif
 #include <math.h>
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
@@ -66,8 +70,13 @@ struct input_device {
   int hats_state[3][2];
   int fd;
   char modifiers;
+  #ifdef __linux__
   __s32 mouseDeltaX, mouseDeltaY, mouseVScroll, mouseHScroll;
   __s32 touchDownX, touchDownY, touchX, touchY;
+  #else
+  int32_t mouseDeltaX, mouseDeltaY, mouseVScroll, mouseHScroll;
+  int32_t touchDownX, touchDownY, touchX, touchY;
+  #endif
   struct timeval touchDownTime;
   struct timeval btnDownTime;
   short controllerId;

--- a/src/platform.c
+++ b/src/platform.c
@@ -202,6 +202,9 @@ AUDIO_RENDERER_CALLBACKS* platform_get_audio(enum platform system, char* audio_d
     #ifdef HAVE_ALSA
     return &audio_callbacks_alsa;
     #endif
+    #ifdef __FreeBSD__
+    return &audio_callbacks_oss;
+    #endif
   }
   return NULL;
 }


### PR DESCRIPTION
1. Add native OSS audio callback when use x11_vaapi platform for FreeBSD
2. Fixed errors encountered at compile time due to system differences(linux and FreeBSD)
3. Fixed the issue that it took too long to reuse the connection when trying to connect sunshine host on FreeBSD
    This issue is because curl's first try fails due to timeout when reuse last connection, I guess there is no such issue
    on linux. So take the easiest way to fix it

These changes are made to make it easier for moonlight-embedded to migrate to FreeBSD 
Please review. Thanks!