### PR TITLE
Support cursor plane on Rockchip platforms

### DIFF
--- a/src/video/rk.c
+++ b/src/video/rk.c
@@ -487,6 +487,7 @@ int rk_setup(int videoFormat, int width, int height, int redrawRate, void* conte
         }
         plane_props[j] = prop;
         if (!strcmp(prop->name, "type") && (props->prop_values[j] == DRM_PLANE_TYPE_OVERLAY ||
+                                            props->prop_values[j] == DRM_PLANE_TYPE_CURSOR ||
                                             props->prop_values[j] == DRM_PLANE_TYPE_PRIMARY)) {
           plane_id = ovr->plane_id;
         }


### PR DESCRIPTION
[Rockchip's vop2 driver](https://github.com/armbian/linux-rockchip/blob/rk-5.10-rkr6/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c#L10966) from vendor kernel will set plane type to `DRM_PLANE_TYPE_CURSOR` when device tree has defined property `cursor-win-id`.
This property is widely used in rk3588 boards, such as rock-5b: https://github.com/armbian/linux-rockchip/blob/rk-5.10-rkr6/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts#L761

This commit will allow moonlight using the cursor plane.
