### PR TITLE
x11 input in pi/mmal mode 

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -77,6 +77,7 @@ static struct option long_options[] = {
   {"pin", required_argument, NULL, '5'},
   {"port", required_argument, NULL, '6'},
   {"hdr", no_argument, NULL, '7'},
+  {"x11input", no_argument, NULL, '8'},
   {0, 0, 0, 0},
 };
 
@@ -260,6 +261,10 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
   case '7':
     config->hdr = true;
     break;
+  case '8':
+    config->x11input = true;
+    printf("> Using x11 for input\n");
+    break;
   case 1:
     if (config->action == NULL)
       config->action = value;
@@ -399,7 +404,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   } else {
     int option_index = 0;
     int c;
-    while ((c = getopt_long_only(argc, argv, "-abc:d:efg:h:i:j:k:lm:no:p:q:r:s:tu:v:w:xy45:6:7", long_options, &option_index)) != -1) {
+    while ((c = getopt_long_only(argc, argv, "-abc:d:efg:h:i:j:k:lm:no:p:q:r:s:tu:v:w:xy45:6:7:8", long_options, &option_index)) != -1) {
       parse_argument(c, optarg, config);
     }
   }

--- a/src/config.h
+++ b/src/config.h
@@ -48,6 +48,7 @@ typedef struct _CONFIGURATION {
   bool hdr;
   int pin;
   unsigned short port;
+  bool x11input;
 } CONFIGURATION, *PCONFIGURATION;
 
 extern bool inputAdded;

--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -776,6 +776,7 @@ static int evdev_handle(int fd) {
 }
 
 void evdev_create(const char* device, struct mapping* mappings, bool verbose, int rotate) {
+  printf("> Evdev create\n");
   int fd = open(device, O_RDWR|O_NONBLOCK);
   if (fd <= 0) {
     fprintf(stderr, "Failed to open device %s\n", device);

--- a/src/input/udev.c
+++ b/src/input/udev.c
@@ -46,6 +46,7 @@ static int udev_handle(int fd) {
       const char *devnode = udev_device_get_devnode(dev);
       int id;
       if (devnode != NULL && sscanf(devnode, "/dev/input/event%d", &id) == 1) {
+        printf("> Udev handle\n");
         evdev_create(devnode, defaultMappings, debug, inputRotate);
       }
     }
@@ -76,6 +77,7 @@ void udev_init(bool autoload, struct mapping* mappings, bool verbose, int rotate
       const char *devnode = udev_device_get_devnode(dev);
       int id;
       if (devnode != NULL && sscanf(devnode, "/dev/input/event%d", &id) == 1) {
+        printf("> Udev init\n");
         evdev_create(devnode, mappings, verbose, rotate);
       }
       udev_device_unref(dev);

--- a/src/input/x11.c
+++ b/src/input/x11.c
@@ -31,6 +31,8 @@
 #include <stdlib.h>
 #include <poll.h>
 
+#include <stdio.h>
+
 #define ACTION_MODIFIERS (MODIFIER_SHIFT|MODIFIER_ALT|MODIFIER_CTRL)
 #define QUIT_KEY 0x18  /* KEY_Q */
 
@@ -47,6 +49,7 @@ static Cursor cursor;
 static bool grabbed = True;
 
 static int x11_handler(int fd) {
+  // printf("> X handler\n");
   XEvent event;
   int button = 0;
   int motion_x, motion_y;
@@ -131,12 +134,13 @@ static int x11_handler(int fd) {
     case MotionNotify:
       motion_x = event.xmotion.x - last_x;
       motion_y = event.xmotion.y - last_y;
+      // printf("> motion [%dx%d]\n", motion_x, motion_y);
       if (abs(motion_x) > 0 || abs(motion_y) > 0) {
         if (last_x >= 0 && last_y >= 0)
           LiSendMouseMoveEvent(motion_x, motion_y);
 
         if (grabbed)
-          XWarpPointer(display, None, window, 0, 0, 0, 0, 640, 360);
+         XWarpPointer(display, None, window, 0, 0, 0, 0, 640, 360);
       }
 
       last_x = grabbed ? 640 : event.xmotion.x;
@@ -168,4 +172,13 @@ void x11_input_init(Display* x11_display, Window x11_window) {
   XDefineCursor(display, window, cursor);
 
   loop_add_fd(ConnectionNumber(display), x11_handler, POLLIN | POLLERR | POLLHUP);
+}
+
+void x11_inputonly_init(Display* x11_display, Window x11_window) {
+  display = x11_display;
+  window = x11_window;
+
+  loop_add_fd(ConnectionNumber(display), x11_handler, POLLIN | POLLERR | POLLHUP);
+
+  printf("> X connection num: %d\n", ConnectionNumber(display));
 }

--- a/src/input/x11.h
+++ b/src/input/x11.h
@@ -20,3 +20,4 @@
 #include <X11/Xlib.h>
 
 void x11_input_init(Display* display, Window window);
+void x11_inputonly_init(Display* display, Window window);

--- a/src/loop.c
+++ b/src/loop.c
@@ -103,8 +103,10 @@ void loop_init() {
 }
 
 void loop_main() {
+  printf("> Loop main\n");
   while (poll(fds, numFds, -1)) {
     for (int i=0;i<numFds;i++) {
+      // printf("> i: %d\n", i);
       if (fds[i].revents > 0) {
         int ret = fdHandlers[i](fds[i].fd);
         if (ret == LOOP_RETURN) {

--- a/src/main.c
+++ b/src/main.c
@@ -219,6 +219,10 @@ static void help() {
   printf("\n WM options (SDL and X11 only)\n\n");
   printf("\t-windowed\t\tDisplay screen in a window\n");
   #endif
+  #if defined(HAVE_X11)
+  printf("\n Input compatibility for touchpads etc (X11 only)\n\n");
+  printf("\t-x11input\t\tUse libinput for local input handling.\n");
+  #endif
   #ifdef HAVE_EMBEDDED
   printf("\n I/O options (Not for SDL)\n\n");
   printf("\t-input <device>\t\tUse <device> as input. Can be used multiple times\n");
@@ -251,6 +255,7 @@ int main(int argc, char* argv[]) {
       exit(-1);
     }
 
+    printf("> Map\n");
     evdev_create(config.inputs[0], NULL, config.debug_level > 0, config.rotate);
     evdev_map(config.inputs[0]);
     exit(0);
@@ -366,6 +371,7 @@ int main(int argc, char* argv[]) {
           if (config.debug_level > 0)
             printf("Adding input device %s...\n", config.inputs[i]);
 
+          printf("> Embedded input\n");
           evdev_create(config.inputs[i], mappings, config.debug_level > 0, config.rotate);
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -139,13 +139,17 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
     connection_debug = true;
   }
 
-  if (IS_EMBEDDED(system))
+  if (IS_EMBEDDED(system) || config->x11input)
     loop_init();
 
   platform_start(system);
+
+  if( config->x11input )
+    x11_dummy_init();
+
   LiStartConnection(&server->serverInfo, &config->stream, &connection_callbacks, platform_get_video(system), platform_get_audio(system, config->audio_device), NULL, drFlags, config->audio_device, 0);
 
-  if (IS_EMBEDDED(system)) {
+  if (IS_EMBEDDED(system) && !(config->x11input)) {
     if (!config->viewonly)
       evdev_start();
     loop_main();
@@ -156,6 +160,9 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
   else if (system == SDL)
     sdl_loop();
   #endif
+
+  if( config->x11input )
+    loop_main();
 
   LiStopConnection();
 
@@ -350,7 +357,7 @@ int main(int argc, char* argv[]) {
       if (config.debug_level > 0)
         printf("View-only mode enabled, no input will be sent to the host computer\n");
     } else {
-      if (IS_EMBEDDED(system)) {
+      if (IS_EMBEDDED(system) && !(config.x11input)) {
         char* mapping_env = getenv("SDL_GAMECONTROLLERCONFIG");
         if (config.mapping == NULL && mapping_env == NULL) {
           fprintf(stderr, "Please specify mapping file as default mapping could not be found.\n");
@@ -367,11 +374,12 @@ int main(int argc, char* argv[]) {
           mappings = map;
         }
 
+        printf("> Embedded input\n");
+
         for (int i=0;i<config.inputsCount;i++) {
           if (config.debug_level > 0)
             printf("Adding input device %s...\n", config.inputs[i]);
 
-          printf("> Embedded input\n");
           evdev_create(config.inputs[i], mappings, config.debug_level > 0, config.rotate);
         }
 
@@ -388,6 +396,8 @@ int main(int argc, char* argv[]) {
           fprintf(stderr, "You can't select input devices as SDL will automatically use all available controllers\n");
           exit(-1);
         }
+
+        printf("> SDL input\n");
 
         sdlinput_init(config.mapping);
         rumble_handler = sdlinput_rumble;

--- a/src/platform.c
+++ b/src/platform.c
@@ -106,6 +106,7 @@ enum platform platform_check(char* name) {
 }
 
 void platform_start(enum platform system) {
+  printf("> Starting Platform 0x%02X\n", system);
   switch (system) {
   #ifdef HAVE_AML
   case AML:

--- a/src/video/video.h
+++ b/src/video/video.h
@@ -37,6 +37,7 @@
 
 #ifdef HAVE_X11
 int x11_init(bool vdpau, bool vaapi);
+int x11_dummy_init();
 extern DECODER_RENDERER_CALLBACKS decoder_callbacks_x11;
 #ifdef HAVE_VAAPI
 extern DECODER_RENDERER_CALLBACKS decoder_callbacks_x11_vaapi;

--- a/src/video/x11.c
+++ b/src/video/x11.c
@@ -82,6 +82,31 @@ int x11_init(bool vdpau, bool vaapi) {
   return INIT_EGL;
 }
 
+int x11_dummy_init() {
+  XInitThreads();
+  display = XOpenDisplay(NULL);
+  if (!display)
+    return 0;
+
+  printf("> X Display opened\n");
+
+  Window root = DefaultRootWindow(display);
+  window = root;
+
+  // XGrabKey(display, AnyKey, AnyModifier, window, True, GrabModeAsync, GrabModeAsync);
+
+  // XSelectInput(display, root, PointerMotionMask | ButtonPressMask | ButtonReleaseMask | KeyPressMask | KeyReleaseMask);
+
+  XGrabKeyboard(display, root, True, GrabModeAsync, GrabModeAsync, CurrentTime);
+  XGrabPointer(display, root, True, PointerMotionMask | ButtonPressMask | ButtonReleaseMask, GrabModeAsync, GrabModeAsync, None, None, CurrentTime);
+
+  printf("> X Input grabbed\n");
+
+  x11_inputonly_init(display, window);
+
+  return 1;
+}
+
 int x11_setup(int videoFormat, int width, int height, int redrawRate, void* context, int drFlags) {
   ensure_buf_size(&ffmpeg_buffer, &ffmpeg_buffer_size, INITIAL_DECODER_BUFFER_SIZE + AV_INPUT_BUFFER_PADDING_SIZE);
 


### PR DESCRIPTION
This a working poc, tested on rpi 3, mmal output with xorg inputs.

**Motivation**
moonlight-embeded has significant performance benefits over moonlight-qt with raspberry pi 3, but capturing inputs via raw input devices causes certain touchpads to not have right click

**Description**
Adds `-x11input` parameter, which causes input devices to be captured via xorg, rather than raw devices, independently from output mode.

**Purpose**
Enables use of touchpads which rely on libinput for right click and tapping