### PR TITLE
Add Haiku support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,11 @@ option(ENABLE_X11 "Compile X11 support (requires ENABLE_FFMPEG)" ON)
 option(ENABLE_CEC "Compile CEC support" ON)
 option(ENABLE_PULSE "Compile PulseAudio support" ON)
 
-pkg_check_modules(EVDEV REQUIRED libevdev)
-pkg_check_modules(UDEV REQUIRED libudev)
+if(NOT HAIKU)
+  pkg_check_modules(EVDEV REQUIRED libevdev)
+  pkg_check_modules(UDEV REQUIRED libudev)
+endif()
+
 if (ENABLE_SDL)
   pkg_check_modules(SDL sdl2>=2.0.4)
 endif()
@@ -223,8 +226,15 @@ endif()
 configure_file("./src/configuration.h.in" "${PROJECT_BINARY_DIR}/configuration.h")
 
 set_property(TARGET moonlight PROPERTY COMPILE_DEFINITIONS ${MOONLIGHT_DEFINITIONS})
-target_include_directories(moonlight PRIVATE ${GAMESTREAM_INCLUDE_DIR} ${MOONLIGHT_COMMON_INCLUDE_DIR} ${OPUS_INCLUDE_DIRS} ${EVDEV_INCLUDE_DIRS} ${UDEV_INCLUDE_DIRS})
-target_link_libraries(moonlight ${EVDEV_LIBRARIES} ${OPUS_LIBRARY} ${UDEV_LIBRARIES} ${CMAKE_DL_LIBS})
+
+if (HAIKU)
+  target_include_directories(moonlight PRIVATE ${GAMESTREAM_INCLUDE_DIR} ${MOONLIGHT_COMMON_INCLUDE_DIR} ${OPUS_INCLUDE_DIRS})
+  target_link_libraries(moonlight ${OPUS_LIBRARY} ${CMAKE_DL_LIBS})
+  target_link_libraries(moonlight network)
+else()
+  target_include_directories(moonlight PRIVATE ${GAMESTREAM_INCLUDE_DIR} ${MOONLIGHT_COMMON_INCLUDE_DIR} ${OPUS_INCLUDE_DIRS} ${EVDEV_INCLUDE_DIRS} ${UDEV_INCLUDE_DIRS})
+  target_link_libraries(moonlight ${EVDEV_LIBRARIES} ${OPUS_LIBRARY} ${UDEV_LIBRARIES} ${CMAKE_DL_LIBS})
+endif()
 
 add_subdirectory(docs)
 

--- a/libgamestream/CMakeLists.txt
+++ b/libgamestream/CMakeLists.txt
@@ -6,7 +6,9 @@ find_package(CURL REQUIRED)
 find_package(OpenSSL 1.0.2 REQUIRED)
 find_package(EXPAT REQUIRED)
 
+if (NOT HAIKU)
 pkg_check_modules(AVAHI REQUIRED avahi-client)
+endif()
 
 aux_source_directory(./ GAMESTREAM_SRC_LIST)
 aux_source_directory(../third_party/h264bitstream GAMESTREAM_SRC_LIST)
@@ -15,17 +17,34 @@ aux_source_directory(../third_party/moonlight-common-c/enet MOONLIGHT_COMMON_SRC
 aux_source_directory(../third_party/moonlight-common-c/src MOONLIGHT_COMMON_SRC_LIST)
 aux_source_directory(../third_party/moonlight-common-c/reedsolomon MOONLIGHT_COMMON_SRC_LIST)
 
-add_library(moonlight-common SHARED ${MOONLIGHT_COMMON_SRC_LIST})
+# Build shared library by default, but allows user override
+if (NOT DEFINED BUILD_SHARED_LIBS)
+  set(BUILD_SHARED_LIBS ON)
+  set(BUILD_SHARED_LIBS_OVERRIDE ON)
+endif()
 
-add_library(gamestream SHARED ${GAMESTREAM_SRC_LIST})
+add_library(moonlight-common ${MOONLIGHT_COMMON_SRC_LIST})
+add_library(gamestream ${GAMESTREAM_SRC_LIST})
+
+if (BUILD_SHARED_LIBS_OVERRIDE)
+  unset(BUILD_SHARED_LIBS)
+  unset(BUILD_SHARED_LIBS_OVERRIDE)
+endif()
+
 target_link_libraries(gamestream moonlight-common)
 
 set_target_properties(gamestream PROPERTIES SOVERSION ${SO_VERSION} VERSION ${PROJECT_VERSION})
 set_target_properties(moonlight-common PROPERTIES SOVERSION ${SO_VERSION} VERSION ${PROJECT_VERSION})
 
-target_include_directories(gamestream PRIVATE ../third_party/moonlight-common-c/src ../third_party/h264bitstream ${AVAHI_INCLUDE_DIRS} ${LibUUID_INCLUDE_DIRS})
+if(HAIKU)
+    target_include_directories(gamestream PRIVATE ../third_party/moonlight-common-c/src ../third_party/h264bitstream ${LibUUID_INCLUDE_DIRS})
+    target_link_libraries(gamestream ${CURL_LIBRARIES} ${OPENSSL_LIBRARIES} ${EXPAT_LIBRARIES} ${LibUUID_LIBRARIES})
+else()
+    target_include_directories(gamestream PRIVATE ../third_party/moonlight-common-c/src ../third_party/h264bitstream ${AVAHI_INCLUDE_DIRS} ${LibUUID_INCLUDE_DIRS})
+    target_link_libraries(gamestream ${CURL_LIBRARIES} ${OPENSSL_LIBRARIES} ${EXPAT_LIBRARIES} ${AVAHI_LIBRARIES} ${LibUUID_LIBRARIES})
+endif()
+
 target_include_directories(moonlight-common PRIVATE ../third_party/moonlight-common-c/reedsolomon ../third_party/moonlight-common-c/enet/include)
-target_link_libraries(gamestream ${CURL_LIBRARIES} ${OPENSSL_LIBRARIES} ${EXPAT_LIBRARIES} ${AVAHI_LIBRARIES} ${LibUUID_LIBRARIES})
 
 target_link_libraries(gamestream ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 

--- a/libgamestream/discover.c
+++ b/libgamestream/discover.c
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef __HAIKU__
 
 #include "errors.h"
 
@@ -116,3 +117,5 @@ void gs_discover_server(char* dest, unsigned short* port) {
   if (simple_poll)
     avahi_simple_poll_free(simple_poll);
 }
+
+#endif

--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -17,6 +17,8 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __HAIKU__
+
 #include "evdev.h"
 
 #include "keyboard.h"
@@ -1123,3 +1125,5 @@ void evdev_rumble(unsigned short controller_id, unsigned short low_freq_motor, u
   write(device->fd, (const void*) &event, sizeof(event));
   device->haptic_effect_id = effect.id;
 }
+
+#endif

--- a/src/input/udev.c
+++ b/src/input/udev.c
@@ -17,6 +17,8 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __HAIKU__
+
 #include "../loop.h"
 
 #include "udev.h"
@@ -99,3 +101,5 @@ void udev_destroy() {
   udev_monitor_unref(udev_mon);
   udev_unref(udev);
 }
+
+#endif

--- a/src/loop.c
+++ b/src/loop.c
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef __HAIKU__
 
 #include "loop.h"
 
@@ -114,3 +115,4 @@ void loop_main() {
     }
   }
 }
+#endif


### PR DESCRIPTION
**Description**
Changes required to run on Haiku

- Possibility of static link for libgamestream (If not done, it creates libraries that have the path hardcoded)
- Haiku's network library is linked for the use of sockets
- The use of discover.c is disabled, since Haiku does not have Avahi
- The use of evdev.c and udev.c is disabled (Haiku does not have these libraries)
- loop.c is disabled since Haiku does not have signalfd.h

**Bugs**

- Error message: setsockopt(TCP_NOOPT, 1) failed: -2147483643
- The cursor cannot be moved out of the window
- "make install" does not work, so it is not installed within the system, it remains as a "portable" executable