### PR TITLE
Fix: Correct assignment logic in XML status checks

### DIFF
--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -750,7 +750,7 @@ int gs_start_app(PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, b
   else
     goto cleanup;
 
-  if ((ret = xml_status(data->memory, data->size) != GS_OK))
+  if ((ret = xml_status(data->memory, data->size)) != GS_OK)
     goto cleanup;
   else if ((ret = xml_search(data->memory, data->size, "gamesession", &result)) != GS_OK &&
            (ret = xml_search(data->memory, data->size, "resume", &result)) != GS_OK)
@@ -793,7 +793,7 @@ int gs_quit_app(PSERVER_DATA server) {
   if ((ret = http_request(url, data)) != GS_OK)
     goto cleanup;
 
-  if ((ret = xml_status(data->memory, data->size) != GS_OK))
+  if ((ret = xml_status(data->memory, data->size)) != GS_OK)
     goto cleanup;
   else if ((ret = xml_search(data->memory, data->size, "cancel", &result)) != GS_OK)
     goto cleanup;


### PR DESCRIPTION
Purpose
The purpose of this PR is to fix a logical operator precedence bug in libgamestream/client.c. Specifically, it ensures that the actual return value from xml_status() is correctly assigned to the ret variable before being evaluated against GS_OK.

Description
In the original code, the assignment was written as:
if ((ret = xml_status(data->memory, data->size) != GS_OK))

In C, the inequality operator (!=) has higher precedence than the assignment operator (=). This caused the following unintended behavior:

The expression xml_status(...) != GS_OK was evaluated first, resulting in a boolean value (0 or 1).

This boolean result was then assigned to ret, causing the original error code returned by xml_status to be lost.

Changes Made:
Modified gs_start_app and gs_quit_app to wrap the assignment in parentheses:
if ((ret = xml_status(data->memory, data->size)) != GS_OK)

This ensures ret captures the specific error code for proper error handling and debugging downstream.

Impact
Reliability: Prevents the loss of specific error codes during the application start/quit sequences.

Correctness: Ensures that the cleanup labels receive the actual status code rather than a generic boolean flag.