### PR TITLE
libgamestream: fix uniqueid.dat read check

### DIFF
--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -92,7 +92,7 @@ static int load_unique_id(const char* keyDirectory) {
   snprintf(uniqueFilePath, PATH_MAX, "%s/%s", keyDirectory, UNIQUE_FILE_NAME);
 
   FILE *fd = fopen(uniqueFilePath, "r");
-  if (fd == NULL || fread(unique_id, UNIQUEID_CHARS, 1, fd) != UNIQUEID_CHARS) {
+  if (fd == NULL || fread(unique_id, UNIQUEID_CHARS, 1, fd) != 1) {
     snprintf(unique_id,UNIQUEID_CHARS+1,"0123456789ABCDEF");
 
     if (fd)


### PR DESCRIPTION
`fread(unique_id, UNIQUEID_CHARS, 1, fd)` returns the number of items read (1 on success), not bytes, so the `!= UNIQUEID_CHARS` comparison is always true. The result is that an existing uniqueid.dat is silently ignored and rewritten with the default `0123456789ABCDEF` on every run, so a custom per-device uniqueid is impossible.

This bit me when pairing a second moonlight-embedded client against a host that keys pairing state by uniqueid (moonshine). Once the first device pairs with the shared default id, the second client is told it's already paired and `gs_pair` bails before ever sending getservercert.

Fix is to compare against the item count. Tested on 2.7.0 (same code as master): with this change a custom uniqueid.dat survives restarts and the second client pairs fine.
