### PR TITLE
fix: make config file parsing stricter and support config includes

### DIFF
--- a/moonlight.conf
+++ b/moonlight.conf
@@ -1,3 +1,9 @@
+## == Example moonlight.conf ==
+## Format: <key> = <value>
+## with strictly one space, one equal sign, one space.
+## Values are treated as string literals, no quotes needed.
+## Anything after a # sign is ignored as a comment.
+
 ## Hostname or IP-address of host to connect to
 ## By default host is autodiscovered using mDNS
 #address = 1.2.3.4

--- a/src/config.c
+++ b/src/config.c
@@ -25,6 +25,9 @@
 #include "input/evdev.h"
 #include "audio/audio.h"
 
+#include <errno.h>
+#include <limits.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -41,6 +44,7 @@
 #define write_config_string(fd, key, value) fprintf(fd, "%s = %s\n", key, value)
 #define write_config_int(fd, key, value) fprintf(fd, "%s = %d\n", key, value)
 #define write_config_bool(fd, key, value) fprintf(fd, "%s = %s\n", key, value ? "true":"false")
+#define FLAG_ON_ERROR(bool_value, error_message, errorFlagPointer, arg) if (!(bool_value)) { fprintf(stderr, "Fatal error: %s %s\n", (error_message), (arg)); *(errorFlagPointer) = true; }
 
 bool inputAdded = false;
 
@@ -79,6 +83,17 @@ static struct option long_options[] = {
   {"hdr", no_argument, NULL, '7'},
   {0, 0, 0, 0},
 };
+
+// trim the right of the string by replacing trailing spaces with NUL chars
+void rtrim(char *in) {
+  size_t len = strlen(in);
+  if (len == 0) return;
+  char *c = in + len - 1;
+  for (;c != in; c--) {
+    if (!isspace((unsigned char)*c)) break;
+    *c = '\0';
+  } 
+}
 
 char* get_path(char* name, char* extra_data_dirs) {
   const char *xdg_config_dir = getenv("XDG_CONFIG_DIR");
@@ -131,7 +146,30 @@ char* get_path(char* name, char* extra_data_dirs) {
   return NULL;
 }
 
-static void parse_argument(int c, char* value, PCONFIGURATION config) {
+// atoi but with sanity checks
+bool safe_atoi(char* val, int* res) {
+  errno = 0;
+  long parsed = strtol(val, NULL, 10);
+  if (errno == EINVAL || parsed > INT_MAX || parsed < INT_MIN) {
+    fprintf(stderr, "Cannot parse %s as an integer\n", val);
+    return false;
+  }
+  *res = parsed;
+  return true;
+}
+
+bool safe_atosui(char* val, short unsigned int* res) {
+  errno = 0;
+  long parsed = strtol(val, NULL, 10);
+  if (errno == EINVAL || parsed > USHRT_MAX || parsed < 0) {
+    fprintf(stderr, "Cannot parse %s as an unsigned short\n", val);
+    return false;
+  }
+  *res = parsed;
+  return true;
+}
+
+static void parse_argument(int c, char* value, bool* has_errors, PCONFIGURATION config) {
   switch (c) {
   case 'a':
     config->stream.width = 1280;
@@ -146,16 +184,16 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
     config->stream.height = 2160;
     break;
   case 'c':
-    config->stream.width = atoi(value);
+    FLAG_ON_ERROR(safe_atoi(value, &(config->stream.width)), "Invalid width specified", has_errors, value)
     break;
   case 'd':
-    config->stream.height = atoi(value);
+    FLAG_ON_ERROR(safe_atoi(value, &(config->stream.height)), "Invalid height specified", has_errors, value)
     break;
   case 'g':
-    config->stream.bitrate = atoi(value);
+    FLAG_ON_ERROR(safe_atoi(value, &(config->stream.bitrate)), "Invalid bitrate specified", has_errors, value)
     break;
   case 'h':
-    config->stream.packetSize = atoi(value);
+    FLAG_ON_ERROR(safe_atoi(value, &(config->stream.packetSize)), "Invalid packetSize specified", has_errors, value)
     break;
   case 'i':
     config->app = value;
@@ -163,7 +201,8 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
   case 'j':
     if (config->inputsCount >= MAX_INPUTS) {
       perror("Too many inputs specified");
-      exit(-1);
+      *has_errors = true;
+      break;
     }
     config->inputs[config->inputsCount] = value;
     config->inputsCount++;
@@ -173,7 +212,7 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
     config->mapping = get_path(value, getenv("XDG_DATA_DIRS"));
     if (config->mapping == NULL) {
       fprintf(stderr, "Unable to open custom mapping file: %s\n", value);
-      exit(-1);
+      *has_errors = true;
     }
     break;
   case 'l':
@@ -186,9 +225,7 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
     config->localaudio = true;
     break;
   case 'o':
-    if (!config_file_parse(value, config))
-      exit(EXIT_FAILURE);
-
+    config_file_parse(value, has_errors, config);
     break;
   case 'p':
     config->platform = value;
@@ -218,7 +255,7 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
       config->stream.audioConfiguration = AUDIO_CONFIGURATION_71_SURROUND;
     break;
   case 'v':
-    config->stream.fps = atoi(value);
+    FLAG_ON_ERROR(safe_atoi(value, &(config->stream.fps)), "Invalid fps specified",  has_errors, value)
     break;
   case 'x':
     if (strcasecmp(value, "auto") == 0)
@@ -240,7 +277,7 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
     config->viewonly = true;
     break;
   case '3':
-    config->rotate = atoi(value);
+    FLAG_ON_ERROR(safe_atoi(value, &(config->rotate)), "Invalid rotate specified", has_errors, value)
     break;
   case 'z':
     config->debug_level = 1;
@@ -252,10 +289,10 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
     config->mouse_emulation = false;
     break;
   case '5':
-    config->pin = atoi(value);
+    FLAG_ON_ERROR(safe_atoi(value, &(config->pin)), "Invalid pin specified", has_errors, value)
     break;
   case '6':
-    config->port = atoi(value);
+    FLAG_ON_ERROR(safe_atosui(value, &(config->port)), "Invalid port specified", has_errors, value)
     break;
   case '7':
     config->hdr = true;
@@ -267,41 +304,63 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
       config->address = value;
     else {
       perror("Too many options");
-      exit(-1);
+      *has_errors = true;
     }
   }
 }
 
-bool config_file_parse(char* filename, PCONFIGURATION config) {
+void config_file_parse(char* filename, bool* has_errors, PCONFIGURATION config) {
   FILE* fd = fopen(filename, "r");
   if (fd == NULL) {
     fprintf(stderr, "Can't open configuration file: %s\n", filename);
-    return false;
+    *has_errors = true;
+    return;
   }
 
   char *line = NULL;
   size_t len = 0;
-
+  bool ok = true;
+  size_t line_num = 0;
+  bool local_error = false;
   while (getline(&line, &len, fd) != -1) {
+    line_num++;
     char *key = NULL, *value = NULL;
-    if (sscanf(line, "%ms = %m[^\n]", &key, &value) == 2) {
+    if (sscanf(line, "%ms = %m[^\n#]", &key, &value) == 2) {
+      rtrim(value);
+      if (strncmp(key, "#", 1) == 0) {
+         continue; // commented keys are gonna be ignored
+      }
       if (strcmp(key, "address") == 0) {
         config->address = value;
       } else if (strcmp(key, "sops") == 0) {
         config->sops = strcmp("true", value) == 0;
+      } else if (strcmp(key, "config") == 0 ) {
+	  config_file_parse(value, &local_error, config);
+	 if (local_error) {
+            fprintf(stderr, "Failed to parse embedded config file [%s] (included from line %lu)\n", value, line_num);
+	    *has_errors = true;
+	    local_error = false;
+         }
       } else {
+	ok = false;
         for (int i=0;long_options[i].name != NULL;i++) {
           if (strcmp(long_options[i].name, key) == 0) {
+            ok = true;
             if (long_options[i].has_arg == required_argument)
-              parse_argument(long_options[i].val, value, config);
+              parse_argument(long_options[i].val, value, has_errors, config);
             else if (strcmp("true", value) == 0)
-              parse_argument(long_options[i].val, NULL, config);
+              parse_argument(long_options[i].val, NULL, has_errors, config);
+	    break; // at this point we've populated the option
           }
         }
+	if (!ok) {
+           fprintf(stderr, "Could not match key %s, can't parse config file [%s] (line %lu)\n", key, filename, line_num);
+	   *has_errors = true;
+	}
       }
     }
   }
-  return true;
+  fclose(fd);
 }
 
 void config_save(char* filename, PCONFIGURATION config) {
@@ -338,7 +397,7 @@ void config_save(char* filename, PCONFIGURATION config) {
   fclose(fd);
 }
 
-void config_parse(int argc, char* argv[], PCONFIGURATION config) {
+void config_parse(int argc, char* argv[], bool* has_errors, PCONFIGURATION config) {
   LiInitializeStreamConfiguration(&config->stream);
 
   config->stream.width = 1280;
@@ -389,19 +448,22 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
 
   char* config_file = get_path("moonlight.conf", "/etc");
   if (config_file)
-    config_file_parse(config_file, config);
+    config_file_parse(config_file, has_errors, config);
 
   if (argc == 2 && access(argv[1], F_OK) == 0) {
     config->action = "stream";
-    if (!config_file_parse(argv[1], config))
-      exit(EXIT_FAILURE);
-
+    config_file_parse(argv[1], has_errors, config);
   } else {
     int option_index = 0;
     int c;
     while ((c = getopt_long_only(argc, argv, "-abc:d:efg:h:i:j:k:lm:no:p:q:r:s:tu:v:w:xy45:6:7", long_options, &option_index)) != -1) {
-      parse_argument(c, optarg, config);
+      parse_argument(c, optarg, has_errors, config);
     }
+  }
+
+  if (*has_errors) {
+    fprintf(stderr, "We had errors in the config or arguments. Aborting further config parse.\n");
+    return; // has_errors is set, it's not worth trying to parse the rest of the file as it may lead to undefined behaviors - main's job
   }
 
   if (config->config_file != NULL)

--- a/src/config.h
+++ b/src/config.h
@@ -52,5 +52,5 @@ typedef struct _CONFIGURATION {
 
 extern bool inputAdded;
 
-bool config_file_parse(char* filename, PCONFIGURATION config);
-void config_parse(int argc, char* argv[], PCONFIGURATION config);
+void config_file_parse(char* filename, bool* has_errors, PCONFIGURATION config);
+void config_parse(int argc, char* argv[], bool* has_errors, PCONFIGURATION config);

--- a/src/main.c
+++ b/src/main.c
@@ -237,7 +237,13 @@ static void pair_check(PSERVER_DATA server) {
 
 int main(int argc, char* argv[]) {
   CONFIGURATION config;
-  config_parse(argc, argv, &config);
+  bool config_errors = false;
+  config_parse(argc, argv, &config_errors, &config);
+  if (config_errors) {
+    fprintf(stderr, "Config has errors. Please fix them and retry.\n");
+    exit(-1);
+  }
+
 
   if (config.action == NULL || strcmp("help", config.action) == 0)
     help();
@@ -273,9 +279,14 @@ int main(int argc, char* argv[]) {
 
   char host_config_file[128];
   sprintf(host_config_file, "hosts/%s.conf", config.address);
-  if (access(host_config_file, R_OK) != -1)
-    config_file_parse(host_config_file, &config);
+  if (access(host_config_file, R_OK) != -1) {
+    config_file_parse(host_config_file, &config_errors, &config);
+    if (config_errors) {
+      fprintf(stderr, "Host config file %s has errors. Please fix them and retry.\n", host_config_file);
+      exit(-1);
+    }
 
+  }
   SERVER_DATA server;
   printf("Connecting to %s...\n", config.address);
 

--- a/tests/invalid-included-file.conf
+++ b/tests/invalid-included-file.conf
@@ -1,0 +1,6 @@
+# this is a bad file, on purpose.
+width = 640
+bad-key = 12
+height = 480.13
+fps = true
+

--- a/tests/moonlight-non-passing.conf
+++ b/tests/moonlight-non-passing.conf
@@ -1,0 +1,16 @@
+# this is an example IMPROPER config file
+# uncomment this and set a proper host for testing
+address = 192.168.1.7
+
+height = 1080 # a fine height
+fps = 120
+bitrate = -1 # a fine bitrate
+
+sops = true
+
+improper-key = 17 # error on line 11
+width = tenfiddy # error on line 12
+port = -5 # error on line 13
+
+config = invalid-included-file.conf  # error on line 15
+config = valid-included-file.conf    # no error on line 16 though

--- a/tests/moonlight-passing.conf
+++ b/tests/moonlight-passing.conf
@@ -1,0 +1,19 @@
+address = 192.168.1.7    # my test machine
+
+# these comments should pose no problem
+#config = /path/to/config
+# config = /path/to/config # will not pose problems either
+## Video streaming configuration
+width = 1920
+height = 1080
+fps = 120
+
+## Bitrate depends by default on resolution and fps
+## Set to -1 to enable default
+## 20Mbps (20000) for 1080p (60 fps)
+## 10Mbps (10000) for 1080p or 60 fps
+## 5Mbps (5000) for lower resolution or fps
+bitrate = -1
+sops = true
+config = valid-included-emptyfile    # this is a valid config file, albeit empty (comment misaligned on purpose)
+config = valid-included-file.conf   # this is a valid config file

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+BUILD_TGT=${BUILD_TGT:-"../build/moonlight"}
+test -e $BUILD_TGT || ( echo "Need moonlight to be built"; exit 1 )
+
+echo "We expect this command to FAIL."
+echo ""
+echo "=================================="
+echo ""
+$BUILD_TGT list -config moonlight-non-passing.conf
+
+echo ""
+echo "=================================="
+echo ""
+echo "We expect this command to SUCCEED."
+echo ""
+echo "=================================="
+echo ""
+$BUILD_TGT list -config moonlight-passing.conf

--- a/tests/valid-included-emptyfile
+++ b/tests/valid-included-emptyfile
@@ -1,0 +1,7 @@
+# This contains only comments
+
+
+
+
+# And empty lines, I must confess.
+# This poses no issues whatsoever.

--- a/tests/valid-included-file.conf
+++ b/tests/valid-included-file.conf
@@ -1,0 +1,3 @@
+width = 640
+height = 480
+fps = 59


### PR DESCRIPTION
**Description**
Improve the config parsing and documentation around it.

- now support comments at the end of lines
- trims values of their trailing whitespaces
- refactor error handling in args and config so that all errors are caught at once (alas, uses a global var in the config module, but it's fair ig)
- safer integer parsing (atoi is known to not care at all for errors)
- error status is now a bool flag carried around, so parser functions are void ...()
- update moonlight.conf with a bit of docs to be explicit about parsing format

**Purpose**
- ensure config supports the features that are documented as working (like includes)
- avoid bad types causing issues (like putting a float in the resolution or whatever)