### PR TITLE
sdl: fix touchscreen input on hosts without native touch support

### DIFF
--- a/src/input/sdl.c
+++ b/src/input/sdl.c
@@ -432,6 +432,12 @@ static void remove_gamepad(SDL_JoystickID sdl_id) {
 void sdlinput_init(char* mappings) {
   memset(gamepads, 0, sizeof(gamepads));
 
+  // Touch is handled above, either natively or by emulating the mouse there.
+  // Letting SDL also synthesise mouse events from touch moves its internal
+  // cursor, and the compositor then re-reports the real pointer once the touch
+  // ends, which arrives as a large spurious motion.
+  SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+
   SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER);
 #if !SDL_VERSION_ATLEAST(2, 0, 9)
   SDL_InitSubSystem(SDL_INIT_HAPTIC);
@@ -542,8 +548,28 @@ int sdlinput_handle_event(SDL_Window* window, SDL_Event* event) {
     event->tfinger.x = SDL_max(SDL_min(1.0f, event->tfinger.x), 0.0f);
     event->tfinger.y = SDL_max(SDL_min(1.0f, event->tfinger.y), 0.0f);
 
-    LiSendTouchEvent(touchEventType, event->tfinger.fingerId, event->tfinger.x, event->tfinger.y,
-                     event->tfinger.pressure, 0.0f, 0.0f, LI_ROT_UNKNOWN);
+    if (LiSendTouchEvent(touchEventType, event->tfinger.fingerId, event->tfinger.x, event->tfinger.y,
+                         event->tfinger.pressure, 0.0f, 0.0f, LI_ROT_UNKNOWN) == LI_ERR_UNSUPPORTED) {
+      // The host has no native touch support, so drive the mouse instead.
+      int w, h;
+      SDL_GetWindowSize(window, &w, &h);
+
+      // A touchscreen is absolute, so position the pointer where the finger is
+      // rather than following the mouse capture mode.
+      switch (event->type) {
+      case SDL_FINGERDOWN:
+        LiSendMousePositionEvent(event->tfinger.x * w, event->tfinger.y * h, w, h);
+        LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, BUTTON_LEFT);
+        break;
+      case SDL_FINGERMOTION:
+        LiSendMousePositionEvent(event->tfinger.x * w, event->tfinger.y * h, w, h);
+        break;
+      case SDL_FINGERUP:
+        // Deliberately no movement here: a release carries no new position.
+        LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, BUTTON_LEFT);
+        break;
+      }
+    }
     break;
   case SDL_CONTROLLERAXISMOTION:
     gamepad = get_gamepad(event->caxis.which, false);


### PR DESCRIPTION
**Description**

`LiSendTouchEvent()` is called for every finger event but its return value is thrown away. On a host with no touch support it returns `LI_ERR_UNSUPPORTED` and nothing gets sent, which is the case `Limelight.h` already tells us to handle:

> If unsupported by the host, this will return LI_ERR_UNSUPPORTED and the caller should consider falling back to mouse emulation

We never did. Touch only seems to work because SDL is separately turning it into mouse events, and that brings its own problem: SDL drags its internal cursor along with your finger, so when you lift it the compositor re-reports the real pointer as one large motion event. In relative mode that goes out as a delta and throws the pointer across the screen. With SDL's synthesis off the same event still arrives, but with a zero delta, so it stops mattering.

This adds the documented fallback and turns the synthesis off, so touch has one path instead of two fighting each other.

I treat touch as absolute rather than following the mouse capture mode, since a touchscreen reports where your finger is, not how far it moved. `SDL_FINGERUP` deliberately sends no movement, because a release has no new position to report, and that was the jump.

Hosts that do support native touch are untouched by this, `LiSendTouchEvent()` succeeds and the fallback never runs.

**Purpose**

Touchscreens are unusable against hosts without native touch support. The pointer follows your finger while you drag, jumps somewhere else the moment you let go, and a tap does not move it at all.

Tested on an Ayn Odin 2 running ROCKNIX, streaming to Sunshine on the SDL platform under Wayland. That host returned `LI_ERR_UNSUPPORTED` for every touch event in a logged session, so this is the path being used. Taps now land where you touch, drags track properly, and letting go leaves the pointer alone. I checked it against an unpatched build of the same commit so I could be sure it was this change and not something else in master.

I do not have a host with native touch support to try, so that side is reasoned from the early return rather than actually tested.
